### PR TITLE
修复IsApnsProduction属性无法提交到接口的问题。因为其在json格式化时，忽略掉了默认值的字段。而该布尔类型的字段默认值为f…

### DIFF
--- a/Jiguang.JPush/Model/Options.cs
+++ b/Jiguang.JPush/Model/Options.cs
@@ -19,7 +19,7 @@ namespace Jiguang.JPush.Model
         /// <summary>
         /// iOS 推送是否为生产环境。默认为 false，开发环境。
         /// </summary>
-        [JsonProperty("apns_production")]
+        [JsonProperty("apns_production",DefaultValueHandling =DefaultValueHandling.Include)]
         public bool IsApnsProduction { get; set; } = false;
 
         [JsonProperty("apns_collapse_id")]


### PR DESCRIPTION
修复IsApnsProduction属性无法提交到接口的问题。因为其在json格式化时，忽略掉了默认值的字段。而该布尔类型的字段默认值为false，所以其总是被忽略掉。导致推送到IOS时，平台一直为生产版的错误。